### PR TITLE
Options maxSize and basePath implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ Default value: based on the path for the current file
 define the base path for the templates, useful when you are using absolute path
 
 #### options.maxSize
-Type: `Number` in bytes
+Type: `Number`
 Default value: Null
 
-define the max size limit for the template be embeded
+define the max size limit in bytes for the template be embeded
 
 ## License
 This module is released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ Default value: 'utf-8'
 
 angular template files encoding
 
+#### options.basePath
+Type: `String`
+Default value: based on the path for the current file
+
+define the base path for the templates, useful when you are using absolute path
+
 ## License
 This module is released under the MIT license.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Default value: based on the path for the current file
 
 define the base path for the templates, useful when you are using absolute path
 
+#### options.maxSize
+Type: `Number` in bytes
+Default value: Null
+
+define the max size limit for the template be embeded
+
 ## License
 This module is released under the MIT license.
 

--- a/index.js
+++ b/index.js
@@ -140,7 +140,11 @@ module.exports = function (options) {
                 var msg = data;
 
                 if (options.skipErrors) {
-                    gutil.log(PLUGIN_NAME, '[WARN]', gutil.colors.magenta(msg));
+                    gutil.log(
+                        PLUGIN_NAME, 
+                        gutil.colors.yellow('[Warning]'),
+                        gutil.colors.magenta(msg)
+                    );
                     replace(base, replaceCallback);
                 } else {
                     pipe.emit('error', new PluginError(PLUGIN_NAME, msg));

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ module.exports = function (options) {
 
         log('\nfile.path: ' + file.path);
 
-        var base = pathModule.dirname(file.path);
+        var base = options.basePath ? options.basePath : pathModule.dirname(file.path);
         replace(base, replaceCallback);
 
         function replaceCallback(code, data) {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   },
   "homepage": "https://github.com/laxa1986/gulp-angular-embed-templates",
   "dependencies": {
-    "through2": "^0.6.5",
     "gulp-util": "^3.0.4",
+    "js-string-escape": "^1.0.0",
     "minimize": "^1.4.1",
-    "js-string-escape": "^1.0.0"
+    "through2": "^2.0.0"
   },
   "devDependencies": {
     "mocha": "^2.0.1",

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -127,4 +127,18 @@ describe('gulp-angular-embed-templates', function () {
             done();
         });
     });
+
+    it('should ignore files bigger than the maxSize specified', function (done) {
+        var tplStats = fs.statSync('test/assets/hello-world-template.html');
+        var sut = embedTemplates({maxSize: tplStats.size - 1});
+        var entry = JSON.stringify({
+            templateUrl: 'test/assets/hello-world-template.html'
+        });
+        var fakeFile = new File({contents: new Buffer(entry)});
+        sut.write(fakeFile);
+        sut.once('data', function (file) {
+            assert.equal(file.contents.toString('utf8'), entry);
+            done();
+        });
+    });
 });

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -113,4 +113,18 @@ describe('gulp-angular-embed-templates', function () {
             done();
         });
     });
+
+    it('should use basePath to find the templates if specified', function (done) {
+        var tplStats = fs.statSync('test/assets/hello-world-template.html');
+        var sut = embedTemplates({ basePath: 'test' });
+        var entry = JSON.stringify({
+            templateUrl: '/assets/hello-world-template.html'
+        });
+        var fakeFile = new File({contents: new Buffer(entry)});
+        sut.write(fakeFile);
+        sut.once('data', function (file) {
+            assert.equal(file.contents.toString('utf8'), '{template:\'<strong>Hello World!</strong>\'}');
+            done();
+        });
+    });
 });

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -28,12 +28,12 @@ describe('gulp-angular-embed-templates', function () {
             assert(file.isBuffer());
 
             // check the contents
-            assert.equal(file.contents.toString('utf8'),
-                'angular.module(\'test\').directive(\'helloWorld\', function () {\r\n' +
-                '    return {\r\n' +
-                '        restrict: \'E\',\r\n' +
-                '        template:\'<strong>Hello World!</strong>\'\r\n' +
-                '    };\r\n' +
+            assert.equal(file.contents.toString('utf8').replace(/\r\n/, '\n'),
+                'angular.module(\'test\').directive(\'helloWorld\', function () {\n' +
+                '    return {\n' +
+                '        restrict: \'E\',\n' +
+                '        template:\'<strong>Hello World!</strong>\'\n' +
+                '    };\n' +
                 '});'
             );
             done();


### PR DESCRIPTION
- Add the ability to change the base path for the templates using options.basePath;
- Add the ability to ignore templates with size bigger than options.maxSize in bytes;
- Upgrade dependency `through2`;