### PR TITLE
Ability to bypass Minimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Default value: Null
 define the max size limit in bytes for the template be embeded. Ignore templates which size exceed this limit
 
 #### options.useMinimizer
-type: 'Boolean'
+type: `Boolean`
 Default value: true
 
 Allows the minimizer to be bypassed, in case minification is already completed before using this plugin.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Default value: Null
 
 define the max size limit in bytes for the template be embeded. Ignore templates which size exceed this limit
 
+#### options.useMinimizer
+type: 'Boolean'
+Default value: true
+
+Allows the minimizer to be bypassed, in case minification is already completed before using this plugin.
+
 ## License
 This module is released under the MIT license.
 

--- a/index.js
+++ b/index.js
@@ -46,8 +46,8 @@ module.exports = function (options) {
     if (options.debug === true) {
         debug = true;
     }
-    if (!options.useMinimizer){
-        options.useMinimizer = true;
+    if (options.useMinimizer == undefined){
+        options.useMinimizer = false;
     }
 
     var minimizer = new Minimize(options.minimize);

--- a/index.js
+++ b/index.js
@@ -46,6 +46,9 @@ module.exports = function (options) {
     if (options.debug === true) {
         debug = true;
     }
+    if (!options.useMinimizer){
+        options.useMinimizer = true;
+    }
 
     var minimizer = new Minimize(options.minimize);
 
@@ -103,17 +106,24 @@ module.exports = function (options) {
                 return;
             }
 
-            minimizer.parse(templateContent, function (err, minifiedContent) {
-                if (err) {
-                    cb(FOUND_ERROR, 'Error while minifying angular template "' + path + '". Error from "minimize" plugin: ' + err);
-                    return;
-                }
+            if(options.useMinimizer){
+                minimizer.parse(templateContent, function (err, minifiedContent) {
+                    if (err) {
+                        cb(FOUND_ERROR, 'Error while minifying angular template "' + path + '". Error from "minimize" plugin: ' + err);
+                        return;
+                    }
 
+                    cb(FOUND_SUCCESS, {
+                        regexpMatch : matches,
+                        template: minifiedContent
+                    });
+                });
+            } else {
                 cb(FOUND_SUCCESS, {
                     regexpMatch : matches,
-                    template: minifiedContent
+                    template: templateContent
                 });
-            });
+            }
         });
     }
 


### PR DESCRIPTION
Small change to allow the bypassing of the Minimizer. This allows for angular 2 beta.0 templates to work properly. Without this change the minimizer changes angular 2 common attributes like *ngIf into lowercase attributes ngif. This causes major problems with angular.

Allowing this bypass is also nice if you have already minified your code elsewhere in your project.