### PR TITLE
Add class support

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function (options) {
 
     // regexp uses 'g' flag to be able to match several occurrences
     // so it should be reset for each file
-    const TEMPLATE_URL_PATTERN = '[\'"]?templateUrl[\'"]?[\\s]*:[\\s]*[\'"`]([^\'"`]+)[\'"`]';
+    const TEMPLATE_URL_PATTERN = '[\'"]?templateUrl[\'"]?[\\s]*([:=])[\\s]*[\'"`]([^\'"`]+)[\'"`]';
 
     // variables which reset for each file
     var content;
@@ -62,7 +62,7 @@ module.exports = function (options) {
     const FOUND_IGNORE = {};
     const CODE_EXIT = {};
 
-    const TEMPLATE_BEGIN = Buffer('template:\'');
+    const TEMPLATE_BEGIN = Buffer('template');
     const TEMPLATE_END = Buffer('\'');
 
     /**
@@ -82,7 +82,7 @@ module.exports = function (options) {
             return;
         }
 
-        var relativeTemplatePath = matches[1];
+        var relativeTemplatePath = matches[2];
         var path = pathModule.join(filePath, relativeTemplatePath);
 
         log('template path: ' + path);
@@ -111,6 +111,7 @@ module.exports = function (options) {
 
                 cb(FOUND_SUCCESS, {
                     regexpMatch : matches,
+                    assignmentOperator: matches[1],
                     template: minifiedContent
                 });
             });
@@ -126,6 +127,8 @@ module.exports = function (options) {
 
             parts.push(Buffer(content.substring(index, matches.index)));
             parts.push(TEMPLATE_BEGIN);
+            parts.push(Buffer(entrance.assignmentOperator));
+            parts.push(Buffer('\''));
             parts.push(Buffer(escapeSingleQuotes(entrance.template)));
             parts.push(TEMPLATE_END);
 
@@ -167,7 +170,7 @@ module.exports = function (options) {
 
                 if (options.skipErrors) {
                     gutil.log(
-                        PLUGIN_NAME, 
+                        PLUGIN_NAME,
                         gutil.colors.yellow('[Warning]'),
                         gutil.colors.magenta(msg)
                     );

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -106,6 +106,24 @@ describe('gulp-angular-embed-templates', function () {
         });
     });
 
+    it('should dial with this.templateUrl={url}', function (done) {
+      var fakeFile = new File({contents: new Buffer('this.templateUrl=\'test/assets/hello-world-template.html\'')});
+      sut.write(fakeFile);
+      sut.once('data', function (file) {
+        assert.equal(file.contents.toString('utf8'), 'this.template=\'<strong>Hello World!</strong>\'');
+        done();
+      });
+    });
+
+    it('should dial with this.templateUrl {SPACES} = {SPACES} {url}', function (done) {
+      var fakeFile = new File({contents: new Buffer('this.templateUrl \t\r\n=\r\n\t \'test/assets/hello-world-template.html\'')});
+      sut.write(fakeFile);
+      sut.once('data', function (file) {
+        assert.equal(file.contents.toString('utf8'), 'this.template=\'<strong>Hello World!</strong>\'');
+        done();
+      });
+    });
+
     it('should skip errors if particular flag specified', function (done) {
         sut = embedTemplates({skipErrors: true});
         var fakeFile = new File({contents: new Buffer(JSON.stringify({


### PR DESCRIPTION
A minor change that should allow users to use a class-based directive for Angular 1 and es6 or TS classes.

You can use inheritance to set up different types of directives and extend them later on, so say we have:

```ts
class Component extends Directive {
  restrict: string = "E";
  controller: Controller;
  controllerAs: string = "vm";
  templateUrl: string = "template.html";
}

class Directive implements angular.IDirective {
  scope: Object = {};
  restrict: string;
  templateUrl: string;

  static Factory(): angular.IDirective {
    return new this();
  };
}

class Controller {...}

angular.module("myModule").directive(Component.Factory);
```

which compiles to

```js
var __extends = (this && this.__extends) || function (d, b) {
    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
    function __() { this.constructor = d; }
    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
};
define(["require", "exports"], function (require, exports) {
    var Component = (function (_super) {
        __extends(Component, _super);
        function Component() {
            _super.apply(this, arguments);
            this.restrict = "E";
            this.controllerAs = "vm";
            this.controller = Controller;
            this.templateUrl = "template.html";
        }
        return Component;
    })(Directive);
    var Directive = (function () {
        function Directive() {
            this.scope = {};
        }
        Directive.Factory = function () {
            return new this();
        };
        ;
        return Directive;
    })();
  var Controller = (function() {
    ...
  })();
});
```

The plugin will now pick up the `this.templateUrl = "template.html"`, and replace it accordingly.

- [x] Add a test.