### PR TITLE
Make Typescript type annotation optional

### DIFF
--- a/lib/Angular2TypeScriptTemplateProcessor.js
+++ b/lib/Angular2TypeScriptTemplateProcessor.js
@@ -10,7 +10,7 @@ var Angular2TypeScriptTemplateProcessor = extend(AngularTemplateProcessor, {
      */
     getPattern : function() {
         // for typescript: 'templateUrl: string = "template.html"'
-        return '[\'"]?templateUrl[\'"]?[\\s]*:[\\s]*string[\\s]*=[\\s]*[\'"`]([^\'"`]+)[\'"`]';
+        return '[\'"]?templateUrl[\'"]?[\\s]*(:[\\s]*string)?[\\s]*=[\\s]*[\'"`]([^\'"`]+)[\'"`]';
     },
 
     embedTemplate : function(match, templateBuffer) {

--- a/lib/Angular2TypeScriptTemplateProcessor.js
+++ b/lib/Angular2TypeScriptTemplateProcessor.js
@@ -10,7 +10,7 @@ var Angular2TypeScriptTemplateProcessor = extend(AngularTemplateProcessor, {
      */
     getPattern : function() {
         // for typescript: 'templateUrl: string = "template.html"'
-        return '[\'"]?templateUrl[\'"]?[\\s]*(:[\\s]*string)?[\\s]*=[\\s]*[\'"`]([^\'"`]+)[\'"`]';
+        return '[\'"]?templateUrl[\'"]?[\\s]*(?::[\\s]*string)?[\\s]*=[\\s]*[\'"`]([^\'"`]+)[\'"`]';
     },
 
     embedTemplate : function(match, templateBuffer) {


### PR DESCRIPTION
A lot of the time, TypeScript can infer types, which means that one doesn't necessarily need to be supplied in all cases.

Therefore, it should be optional.