### PR TITLE
Fixed Object.assign undefined in IE js engine

### DIFF
--- a/lib/Processor.js
+++ b/lib/Processor.js
@@ -1,4 +1,5 @@
 var createLogger = require('./utils').createLogger;
+var objectAssign = require('object-assign');
 
 function Processor() {}
 
@@ -6,7 +7,7 @@ function Processor() {}
  * @param config
  */
 Processor.prototype.init = function(config) {
-    this.config = Object.assign({}, config);
+    this.config = objectAssign({}, config);
     this.logger = createLogger(this.config.logger);
 };
 

--- a/lib/ProcessorEngine.js
+++ b/lib/ProcessorEngine.js
@@ -1,9 +1,10 @@
 var pathModule = require('path');
 var utils = require('./utils');
+var objectAssign = require('object-assign');
 
 var ProcessorEngine = utils.extend(Object, {
     init: function (config) {
-        this.config = Object.assign({}, config);
+        this.config = objectAssign({}, config);
 
         this.logger = utils.createLogger(config.logger);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+var objectAssign = require('object-assign');
+
 /**
  * @param {Function} ParentClass class to extend from
  * @param {Object} prototype methods to be added in child class prototype
@@ -46,7 +48,7 @@ function recursiveCycle(arr, onIteration, onEnd) {
  * @return {Object}
  */
 function createLogger(logger) {
-    var result = logger ? Object.assign({}, logger) : {};
+    var result = logger ? objectAssign({}, logger) : {};
     if (!result.debug) result.debug = console.log;
     if (!result.info) result.info = console.info;
     if (!result.warn) result.warn = console.warn;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gulp-angular2-embed-templates",
+  "name": "gulp-angular-embed-templates",
   "version": "2.2.1",
   "description": "gulp plugin to include the contents of angular templates inside directive's code",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-angular2-embed-templates",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "gulp plugin to include the contents of angular templates inside directive's code",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "gulp-util": "^3.0.6",
     "minimize": "^1.8.1",
     "through2": "^2.0.1",
-    "htmlparser2": "~3.9.0"
+    "htmlparser2": "~3.9.0",
+    "object-assign": "4.0.1"
   },
   "devDependencies": {
     "mocha": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gulp-angular-embed-templates",
+  "name": "gulp-angular2-embed-templates",
   "version": "2.2.0",
   "description": "gulp plugin to include the contents of angular templates inside directive's code",
   "main": "index.js",


### PR DESCRIPTION
_Package fails on:_
Visual Studio 2015 Task Runner
Windows 8.1 (or lower version)

_Reason:_
It uses IE 11 js engine and there is no Object.assign method

_Fix:_
Changed Object.assign with npm package: 'object-assign' 
